### PR TITLE
FusClient: fix 403 Client Error: Forbidden

### DIFF
--- a/common/src/commonMain/kotlin/tk/zwander/common/tools/FusClient.kt
+++ b/common/src/commonMain/kotlin/tk/zwander/common/tools/FusClient.kt
@@ -69,7 +69,7 @@ class FusClient(
     }
 
     fun getDownloadUrl(path: String): String {
-        return generateProperUrl(useProxy, "http://cloud-neofussvr.sslcs.cdngc.net/NF_DownloadBinaryForMass.do?file=${path}")
+        return generateProperUrl(useProxy, "http://cloud-neofussvr.samsungmobile.com/NF_DownloadBinaryForMass.do?file=${path}")
     }
 
     /**


### PR DESCRIPTION
* cloud-neofussvr.sslcs.cdngc.net no longer works for downloading but still works fine for nonce.
* Fixes https://github.com/zacharee/SamloaderKotlin/issues/107