### PR TITLE
FusClient: Handle EUX and EUY CSCs

### DIFF
--- a/common/src/commonMain/kotlin/tk/zwander/common/tools/Request.kt
+++ b/common/src/commonMain/kotlin/tk/zwander/common/tools/Request.kt
@@ -143,13 +143,60 @@ object Request {
                             text("Android")
                         }
                     }
-                }
-                node("Get") {
-                    node("CmdID") {
-                        text("2")
+                // Add additional fields for EUX
+                if (region == "EUX") {
+                    node("DEVICE_AID_CODE") {
+                        node("Data") {
+                            text(region)
+                        }
                     }
-                    node("LATEST_FW_VERSION")
+                    node("DEVICE_CC_CODE") {
+                        node("Data") {
+                            text("DE")
+                        }
+                    }
+                    node("MCC_NUM") {
+                        node("Data") {
+                            text("262")
+                        }
+                    }
+                    node("MNC_NUM") {
+                        node("Data") {
+                            text("01")
+                        }
+                    }
                 }
+
+                // Add additional fields for EUY
+                else if (region == "EUY") {
+                    node("DEVICE_AID_CODE") {
+                        node("Data") {
+                            text(region)
+                        }
+                    }
+                    node("DEVICE_CC_CODE") {
+                        node("Data") {
+                            text("RS")
+                        }
+                    }
+                    node("MCC_NUM") {
+                        node("Data") {
+                            text("220")
+                        }
+                    }
+                    node("MNC_NUM") {
+                        node("Data") {
+                            text("01")
+                        }
+                    }
+                }
+            }
+            node("Get") {
+                node("CmdID") {
+                    text("2")
+                }
+                node("LATEST_FW_VERSION")
+            }
             }
         }
 


### PR DESCRIPTION
* They require 4 extra fields, MCC and MNC are SIM region codes, default to using DE sub region of EUX as it gets updates earlier (Alternatives include RO with MCC 226 and MNC 10)
* For EUY Known working regions are RS with the specified MCC/MNC numbers
* Fixes EUX section of https://github.com/zacharee/SamloaderKotlin/issues/116
* Fixes https://github.com/zacharee/SamloaderKotlin/issues/111


![Screenshot_3](https://github.com/zacharee/SamloaderKotlin/assets/25624482/514db8ae-cf23-44f9-a518-5bf031b82153)
![Screenshot_4](https://github.com/zacharee/SamloaderKotlin/assets/25624482/8af26be6-3888-4253-92de-ce86847671a2)
![Screenshot_2](https://github.com/zacharee/SamloaderKotlin/assets/25624482/f74b8ed1-e57e-462f-a755-e7e6f80d4d2f)
